### PR TITLE
`equations`: don't change labels

### DIFF
--- a/Math/LaTeX/Internal/Display.hs
+++ b/Math/LaTeX/Internal/Display.hs
@@ -111,7 +111,8 @@ equations eqLines garnish = fromLaTeX . TeXEnv "align" [] $ stack eqLines
        (eqnum, terminator) = parseEqnum garnish
 
 asSafeLabel :: String -> LaTeX
-asSafeLabel = LaTeX.label . fromString . filter isAlpha
+asSafeLabel = LaTeX.label . raw . fromString
+                         -- raw: otherwise HaTeX interprets e.g. '_'
 
 -- | Include a formula / equation system as a LaTeX display.
 maths :: (LaTeXC r, LaTeXSymbol σ)


### PR DESCRIPTION
fixes #2 pragmatically

Type-Level specialties can be added when stable.

`equations` interpreted labels with `asSafeLabel :: String -> LaTeX`.
The latter filtered out non-alphabetic characters.

This commit changes `asSafeLabel` to treat the String as raw LaTeX.